### PR TITLE
Correct CWD

### DIFF
--- a/11-dragon.cgi
+++ b/11-dragon.cgi
@@ -16,6 +16,8 @@
 #
  
 use CGI::Carp qw( fatalsToBrowser );
+use File::Basename;
+use lib dirname(__FILE__);
 $| = -1;
 require "11-config.pl";
 $cstamp=time(); $timestamp=sprintf("%08x", $cstamp);

--- a/11-dragon.cgi
+++ b/11-dragon.cgi
@@ -16,8 +16,8 @@
 #
  
 use CGI::Carp qw( fatalsToBrowser );
-use File::Basename;
-use lib dirname(__FILE__);
+use File::Basename; 
+use lib dirname(__FILE__); # Add the parent directory to the @INC
 $| = -1;
 require "11-config.pl";
 $cstamp=time(); $timestamp=sprintf("%08x", $cstamp);

--- a/11-sysop.cgi
+++ b/11-sysop.cgi
@@ -12,8 +12,8 @@
 # http://creativecommons.org/licenses/by-nc/2.0/
 #
 use CGI; use CGI::Carp qw( fatalsToBrowser ); use File::Copy qw(copy); no warnings "all"; $| = -1; 
-use File::Basename;
-use lib dirname(__FILE__);
+use File::Basename; 
+use lib dirname(__FILE__); # Add the parent directory to the @INC 
 require "11-config.pl";
 $ver="1.0";
 print "Content-type: text/html\n";

--- a/11-sysop.cgi
+++ b/11-sysop.cgi
@@ -12,6 +12,8 @@
 # http://creativecommons.org/licenses/by-nc/2.0/
 #
 use CGI; use CGI::Carp qw( fatalsToBrowser ); use File::Copy qw(copy); no warnings "all"; $| = -1; 
+use File::Basename;
+use lib dirname(__FILE__);
 require "11-config.pl";
 $ver="1.0";
 print "Content-type: text/html\n";


### PR DESCRIPTION
11-sysop.cgi and 11-dragon.cgi boldly that 11-config.pl will be located in the current working directory, which is not always the case:
`require "11-config.pl";`

This results in errors when the CWD is not the same as the 11-sysop.cgi file location:
`Can't locate 11-config.pl in @INC (@INC contains: C:/Strawberry/perl/site/lib C:/Strawberry/perl/vendor/lib C:/Strawberry/perl/lib) at C:/[omitted]/DragonBasher/cgi-bin/11-dragon/11-sysop.cgi line 15.`

This solves that issue by adding the parent directory of these files to the @INC.